### PR TITLE
Eliminar cabecera

### DIFF
--- a/complex.py
+++ b/complex.py
@@ -1,9 +1,6 @@
 import re
 import sys
 
-#                                 n
-# Ejemplifica el conjunto de los C  y sus operaciones.
-
 class complejo:
 	""" Representa a un numero complejo """
 	def __init__(self, rI, jI):

--- a/complex.py
+++ b/complex.py
@@ -1,6 +1,9 @@
 import re
 import sys
 
+#
+# Descripcion: Script que ejemplifica el conjunto C de los numeros complejos.
+#
 class complejo:
 	""" Representa a un numero complejo """
 	def __init__(self, rI, jI):


### PR DESCRIPTION
Eliminamos la cabecera por considerarla redundante.